### PR TITLE
Fat repooler update 

### DIFF
--- a/repooler.py
+++ b/repooler.py
@@ -10,6 +10,8 @@ import csv
 import copy
 import click
 import sys
+import os
+import yaml
 
 from time import time
 from datetime import datetime
@@ -18,15 +20,30 @@ from genologics.config import BASEURI, USERNAME, PASSWORD
 from genologics.lims import Lims
 from genologics.entities import Process
 
+def credentials():
+    try:
+        config_file = os.path.join(os.environ.get("HOME"), ".ngi_config", "statusdb.yaml")
+        if not os.path.exists(config_file):
+            config_file = os.path.join(os.environ.get("REPOOLER_CONFIG"))
+        with open(config_file) as f:
+            conf = yaml.load(f)
+            config = conf["statusdb"]
+        return config
+    except IOError:
+        raise IOError(("There was a problem loading the configuration file. "
+                "Please make sure that ~/.ngi_config/statusdb.yaml exists "
+                "or env vairable 'REPOOLER_CONFIG' is set with path to conf "
+                "file and set with read permissions"))
+
 #Assumes ind. sample conc measurements have failed. As such it relies on changing relative volume on already normalized samples and structure
 #Structure are retained as conc measurements failure means there's no way to know conc. delta between samples from seperate poolss
 def connection():
-    user = 'isak'
-    pw = 'Purpleplant89'
-    tools_server = 'tools.scilifelab.se:5984'
-    print("Database server used: http://{}".format(tools_server))
+    config = credentials() 
+    user = config.get("username")
+    pw = config.get("password")
+    print("Database server used: http://{}".format(config.get("url")))
     print("LIMS server used: " + BASEURI)
-    couch = couchdb.Server('http://{}:{}@{}'.format(user, pw, tools_server))
+    couch = couchdb.Server('http://{}:{}@{}:{}'.format(user, pw, config.get("url"), config.get("port")))
     try:
         print "Connecting to statusDB..."
         couch.version()
@@ -78,7 +95,7 @@ def proj_struct(couch, project, target_clusters):
             if not lane in fc_track[project][fc]:
                 fc_track[project][fc][lane] = dict()
             #Only counts samples for the given project, other samples are "auto-filled"
-            if project in sample:
+            if project in sample or sample in "Undetermined":
                 fc_track[project][fc][lane][sample] = clusters
             else:
                 fc_track[project][fc][lane][sample] = target_clusters
@@ -94,11 +111,8 @@ def parse_indata(struct, target_clusters):
     """Takes in data and finds unique lane structure, clusters per sample and lane division"""
     clusters_rem = dict() #Total remaining clusters
     lane_maps = dict() #All possible structs. Sample-aggregate is a string, values are average expression
-    sample_struct = dict() #All possible structs. Each sample is a value.
+    sample_struct = dict() #All possible structs. Values are a list of samples per lane
     copies = dict() #Keeps track of duplicates of each structure
-    #Changed counter from 1 to 0 for lane_maps; uh-oh
-    
-    #TODO: LANES IN SAMPLE_STRUCT IS DISPLAYED TWICE
     
     for fc, lanes in struct.items():
         for lane, samples in lanes.items():
@@ -109,9 +123,10 @@ def parse_indata(struct, target_clusters):
 
             if not map_names in lane_maps:
                 sample_struct[map_names] = mapp
-                lane_maps[map_names] = map_values
+                lane_maps[map_names] = numpy.array(map_values)
                 copies[map_names] = 1
             else:
+                lane_maps[map_names] = lane_maps[map_names] + numpy.array(map_values)
                 copies[map_names] = copies[map_names]+1
                 
             #Calculate remaining clusters for each sample
@@ -119,15 +134,19 @@ def parse_indata(struct, target_clusters):
                 if not sample in clusters_rem:
                     clusters_rem[sample] = target_clusters
                 clusters_rem[sample] -= value
+                
                 if clusters_rem[sample] < 0:
                     clusters_rem[sample] = 0
     
     #Calculate average output of sample for each structure type
     for names, values in lane_maps.items():
         values = numpy.array(values)
+        #Explicit typecast
+        values = values.astype(float)
+        #Calculate average
         lane_maps[names] = values/copies[names]
         #Manually overwrites undetermined to exclude them
-        lane_maps[names][0] = target_clusters
+        #lane_maps[names][0] = 0
 
     return [lane_maps, clusters_rem, sample_struct] 
 
@@ -135,118 +154,97 @@ def parse_indata(struct, target_clusters):
 def simple_unique_set(sample_struct, clusters_rem, target_clusters):
     """Creates a set where every sample uniquely appears once and only once
     Prioritizes lanes with most unsequenced samples first"""
-
-
+    
     #Inline function to calculate number of unfinished samples per lane
     def f(x):
         count = 0
         for sample in x:
             if clusters_rem[sample] < target_clusters:
                 count = count + 1
-        print count
+        #print count
         return count
 
     #Best = Most samples in need of sequencing = End of lists
-    best_cands = OrderedDict(sorted(sample_struct.items(), key=lambda t: f(t[1])))
-    
-    unique_sample_structs = dict()
-    
-    #pop the best candidate
-    prime = best_cands.pop()
-    #List which lanes are excluded from primes inclusion (unique requirement)
-    for name, dupe in prime:
-        excluded = list()
-        for str, lis in best_cands:
-            for sample in lis:
-                if dupe == sample and name != str and sample != 'Undetermined':
-                    excluded.append(str)
+    top_lanes = OrderedDict(sorted(sample_struct.items(), key=lambda t: f(t[1])))
+    confirmed_best = dict()
+    while not top_lanes.keys() == []:
+        #pop the best candidate
+        prime = top_lanes.popitem()
+        #Check that including the prime doesn't induce duplicates
+        sample_ok = True
+        for p_sample in prime[1]:
+            for keys, values in confirmed_best.items():
+                if p_sample in values and p_sample != "Undetermined":
+                    #print("DEBUG: {} is already present in final set, auto-discarding {}".format(p_sample, keys))
+                    sample_ok = False
                     break
-                
-    #CONTINUE FROM HERE!!"
-    #Check that none of the excluded lanes have uniquely present samples
-    for str in excluded:
-        for samples in sample_struct[str]:
-            
-    
-    
-    
-    acceptable = False
-    for key in excluded:
-        total_duplicates = list()
-        for values in lane_maps[key]:
-            duplicate = 0
-            for k, v in lane_maps.items():
-                for dupe in v:
-                    if dupe == values and k != key and sample != 'Undetermined':
-                        acceptable = True
+        #Part 2       
+        if sample_ok:
+            #Check that including prime doesn't block a remaining lane with uniques.
+            #Tally up blocked lanes & samples from them
+            blocked_lanes = list()
+            blocked_samples = list() 
+            for p_sample in prime[1]:
+                for t_key, t_sample in top_lanes.items():
+                    if p_sample in t_sample and p_sample != "Undetermined":
+                        blocked_lanes.append(t_key)
+                        blocked_samples.extend(top_lanes[t_key])
+            #Break if all instances of a sample end up in blocked lanes
+            #Must handle case where no blocked samples happen
+            sample_killed = False
+            for b_sample in set(blocked_samples):
+                sample_killed = True
+                for r_key, r_values in top_lanes.items():
+                    if (b_sample in r_values or b_sample in prime[1]) and r_key not in blocked_lanes:
+                        sample_killed = False
                         break
-            total_duplicates.append(duplicate)
-            
-    if acceptable:
-        #Check that the lane doesn't have sample dupes in the accepted set already
-        for entries in valz:
-            for kuyz, vulz in unique_lane_maps.items():
-                for things in vulz:
-                    if things == entries and entries != 'Undetermined':
-                        acceptable = False
-                        break
-        if acceptable:        
-            unique_lane_maps[keyz] = valz
-                
+            if not sample_killed:
+                confirmed_best[prime[0]] = prime[1]
+                #DEBUG: Remove blocked lanes from top_lanes
+                for b_lane in set(blocked_lanes):
+                    #print ("DEBUG: {} was blocked by another sample's inclusion!".format(b_lane))
+                    del top_lanes[b_lane]      
 
-    validate_samples_unique(unique_lane_maps)
+    validate_samples_unique(confirmed_best)
+    validate_all_samples_present(confirmed_best, sample_struct, clusters_rem)
     
+    return confirmed_best
+
+def validate_samples_unique(lane_maps): 
+    """Crude way to check that no samples are in different TYPES of lanes"""
+    tempList = list()
+
+    #Put all values in a list
+    for k, v in lane_maps.items():
+        for index in xrange(1,len(v)):
+            if not v[index] == 'Undetermined':
+                tempList.append(v[index])
+          
+    #Count instances of all items in the list
+    counter = Counter(tempList)
+    for values in counter.itervalues():
+        if values > 1: 
+            raise Exception('Error: Sample present in multiple structures. Unhandled exception!')
     
-    import pdb
-    pdb.set_trace()
+def validate_all_samples_present(subset_struct, sample_struct, clusters_rem):    
+    """Takes sample_struct and a subset of sample_struct, and checks that all present in sample_struct with remaining clusters
+    also exist in subset_struct"""
+    #Form a list of all samples in sample_struct
+    tempList = list()
+    for key, samplelist in sample_struct.items():
+        for element in samplelist:
+            if not element in tempList and clusters_rem[element] > 0:
+                tempList.append(element)
     
-    unique_lane_maps = dict()
-    for keyz, valz in lane_maps.items():
-        #Fetch what lanes inclusion of given lane excludes
-        excluded = list()
-        for sample in lane_maps:
-            for k, v in lane_maps.items():
-                for dupe in v:
-                    if dupe == sample and keyz != k and sample != 'Undetermined':
-                        excluded.append(k)
-                        break
-        #Check that none of the excluded lanes have uniquely present samples
-        acceptable = True
-        for key in excluded:
-            total_duplicates = list()
-            for values in lane_maps[key]:
-                duplicate = 0
-                for k, v in lane_maps.items():
-                    for dupe in v:
-                        if dupe == values and k != key and sample != 'Undetermined':
-                            duplicate +=1
-                            break
-                total_duplicates.append(duplicate)
-            if 0 in total_duplicates:
-                acceptable = False
+    #Verify that all samples exist in subset_struct
+    for element in tempList:
+        found = False
+        for key, samplelist in subset_struct.items():
+            if element in samplelist:
+                found = True
                 break
-        if acceptable:
-            #Check that the lane doesn't have sample dupes in the accepted set already
-            for entries in valz:
-                for kuyz, vulz in unique_lane_maps.items():
-                    for things in vulz:
-                        if things == entries and entries != 'Undetermined':
-                            acceptable = False
-                            break
-            if acceptable:        
-                unique_lane_maps[keyz] = valz
-                
-
-    validate_samples_unique(unique_lane_maps)
-    #validate_all_samples_present(lane_maps)
-    
-    return unique_lane_maps
-    
-def validate_all_samples_present(lane_maps):    
-    summap = []
-    for k in lane_maps.keys():
-        summap += lane_maps[k]
-    print len(set(summap))   
+        if not found:
+            raise Exception('Error: Sample missing after subset was generated! {} is one of these'.format(element))
     
 def aggregator(lane_maps,clusters_rem,clusters_per_lane):
 #Iterate
@@ -259,176 +257,142 @@ def aggregator(lane_maps,clusters_rem,clusters_per_lane):
     #Ceil(dups) those babies
     raise Exception('Error: Not yet implemented!')
 
-def sample_distributor(lane_maps, clusters_rem, clusters_per_lane):
-    """Gives how many percent of the lane should be allocated to a specific sample"""    
-    ratios_equal_conc = dict()
-    req_lanes = dict()
-    
-    for index in lane_maps:
-        summ = 0
-        for entry in lane_maps[index]:
+def sample_distributor(sample_struct, clusters_rem, clusters_per_lane): 
+    """Gives the percentage volume each sample should have in a lane, BEFORE accounting
+    for concentration offsets"""
+    desired_ratios = dict() 
+    # Key: string of samples. values: Percentage, sample order as sample_struct.values()
+    ideal_lanes = dict()
+    needed_lanes = dict()
+
+    for s_key, s_val in sample_struct.items():
+        #Calculate lane total (sum)
+        lane_total = 0
+        for entry in sample_struct[s_key]:
             if clusters_rem[entry] > 0:
-                summ += clusters_rem[entry]
-        for entry in lane_maps[index]:
-            if not index in ratios_equal_conc:
-                ratios_equal_conc[index] = list()
-            if clusters_rem[entry] > 0:
-                ratios_equal_conc[index].append(clusters_rem[entry]/float(summ))
-            else: 
-                ratios_equal_conc[index].append(0.0)
-        #Minimal number of required lanes per pool
-        req_lanes[index] = summ/float(clusters_per_lane)
-    #Have to be rounded up, rounding down when only using duplicates makes no sense
-    total_lanes = map(math.ceil, req_lanes.values())
-    
-    return [ratios_equal_conc, req_lanes, total_lanes]
-
-
-def validate_samples_unique(lane_maps): 
-    """Crude way to check that no samples are in different TYPES of lanes"""
-    tempList = list()
-    
-    for k, v in lane_maps.items():
-        for index in xrange(1,len(v)):
-            if not v[index] == 'Undetermined':
-                tempList.append(v[index])
-    counter = Counter(tempList)
-    for values in counter.itervalues():
-        if values > 1: 
-            raise Exception('Error: This app does NOT handle situations where a sample' 
-            'is present in lanes/well with differing structure!')
-
-
-def fix_conc_offset(lane_maps, clusters_expr, ratios_equal_conc):
-    """Since some samples are strong and some weaksauce
-    10% in ratios_equal_conc does not mean 10% of lane volume
-    As such, ratios_equal_conc need to be divided by actual_reads/expected_reads
-    Ignores undetermined clusters in calculation
-    Assumes sample conc cant be altered; aka only volume is modified"""
-    #THIS IS BROKEN, SINCE SAMPLES MAY HAVE BEEN SEQUENCED IN DIFFERENT POOLS
-    
-    for ind in xrange(1, len(lane_maps.keys())+1):
-        #Bases w/o sample are not expected
-        if len(lane_maps[ind]) != 1:
-            exp = 1/float(len(lane_maps[ind])-1)
-        else:
-            exp = 1
-        laneTypeExpr = 0
-        counter = 0
-        for sample in lane_maps[ind]:
-            if not sample == 'Undetermined':
-                laneTypeExpr += clusters_expr[sample]
-        for sample in lane_maps[ind]:
-            act = clusters_expr[sample]/float(laneTypeExpr)
-            ratios_equal_conc[ind][counter] = ratios_equal_conc[ind][counter]*(exp/act)
-            counter += 1
-                   
-    #Normalizes numbers
-    for index in xrange(1, len(ratios_equal_conc.keys())+1):
-        curSum = sum(ratios_equal_conc[index])    
-        for sample in xrange(0, len(ratios_equal_conc[index])):
-            if curSum == 0:
-                ratios_equal_conc[index][sample] = 0
-            else:
-                ratios_equal_conc[index][sample] = (ratios_equal_conc[index][sample]/curSum)*100
-
-def realize_numbers(lane_maps, clusters_expr, ratios_equal_conc, req_lanes, total_lanes):
-    """Actual numbers need to be offset to: 
-    A) Work with a pipette of min 2uL 
-    B) Work with a pipette with an increase of 0.1*x uL
-    C) Downsize under 100%"""
-    added=0
-    
-    #Fixes ratios_equal_conc
-    fix_conc_offset(lane_maps, clusters_expr, ratios_equal_conc)
-    acc_ratios = copy.deepcopy(ratios_equal_conc)
-
-    ##DOUBLECHECK ROUNDING
-    #Set A
-    for i in ratios_equal_conc:
-        dupes=total_lanes[i-1]
-        minTres=round(200/(float(dupes*5)), 2)
-        minAdd= round(200/(float(dupes*5*20)), 2)
-        for sample in ratios_equal_conc[i]:
-            sampleIndex = acc_ratios[i].index(sample)
-            if sample < minTres and not sample == 0.0:
-                acc_ratios[i][sampleIndex] = minTres
-            #Sets B
-            elif not round(sample, 2) % minAdd == 0 and not sample == 0.0:
-                acc_ratios[i][sampleIndex] = (ratios_equal_conc[i][sampleIndex] 
-                                              - (sample % minAdd) + minAdd)
-            #Silly float fix
-            acc_ratios[i][sampleIndex] = round(acc_ratios[i][sampleIndex], 2)
-
-    #Sets C
-    for i in acc_ratios:
-        while not sum(acc_ratios[i]) <= 100.0:
-            stuck = True
-            for sample in acc_ratios[i]:
-                sampleIndex = acc_ratios[i].index(sample)
-                dupes=total_lanes[i-1]
-                minAdd=round(200/(float(dupes*5*20)), 2)
-                minTres=round(200/(float(dupes*5)), 2)
+                lane_total += clusters_rem[entry] 
                 
-                #Bit dumb, should find the one with biggest diff and remove from it, instead of just ordered
-                if sum(acc_ratios[i]) <= 100.0:
-                    break
-                elif (not acc_ratios[i][sampleIndex] == 0.0 and not acc_ratios[i][sampleIndex]-minAdd < minTres and
-                (acc_ratios[i][sampleIndex]- minAdd)*total_lanes[i-1]  > ratios_equal_conc[i][sampleIndex]*req_lanes[i]):
-                    acc_ratios[i][sampleIndex] = round(acc_ratios[i][sampleIndex]-minAdd, 2)
-                    stuck = False
-            if stuck:
-                total_lanes[i-1] = total_lanes[i-1] + 1
-                added = added + 1
-    print "Lanes added due to  pipette limitations: {}".format(added)
-    #SPECIAL CODE:
-    #Upscales all results to 100%. Leaves a miniature pool of sample left, but whatever.
-    #Make sure to fix csv file after this
-    for i in acc_ratios:
-        if sum(acc_ratios[i]) < 100:
-            total = sum(acc_ratios[i])/100 
-            for sample in acc_ratios[i]:
-                acc_ratios[i][acc_ratios[i].index(sample)] = round(acc_ratios[i][acc_ratios[i].index(sample)]/float(total), 2)     
-    return acc_ratios, added 
-     
-def round_whole(lane_maps, clusters_expr, ratios_equal_conc, req_lanes, total_lanes):
-    """Old rounding that made some faulty assumptions about pool sizes
+        ideal_lanes[s_key] = lane_total/float(clusters_per_lane)  
+        needed_lanes[s_key] = math.ceil(ideal_lanes[s_key])  
+        
+        #Populate output sample rates
+        desired_ratios[s_key] = []
+        for entry in sample_struct[s_key]:
+            if lane_total == 0:
+                desired_ratios[s_key].append(0)
+            elif clusters_rem[entry] > 0:
+                desired_ratios[s_key].append(clusters_rem[entry]/float(lane_total))
+            else: 
+                desired_ratios[s_key].append(0/float(lane_total))
     
-    Translates float -> int without underexpressing anything
-    Iteratively rounds to whole percent (min pipette for volume) to reach 100%
-    ideal_ratio * req_lanes.values() = needed
-    acc_ratio * total_lanes = current
-    means a sample can take any whole number between the two"""
-    
-    added = 0
-    #Fixes ratios_equal_conc
-    fix_conc_offset(lane_maps, clusters_expr, ratios_equal_conc)
-    acc_ratios = copy.deepcopy(ratios_equal_conc)
-            
-    for index in xrange(1, len(ratios_equal_conc.keys())+1):
-        for sample in xrange(0, len(ratios_equal_conc[index])):
-            acc_ratios[index][sample] = math.ceil(ratios_equal_conc[index][sample])
-        if sum(acc_ratios[index]) == 100:
-            break
-        else:
-            while sum(acc_ratios[index]) > 100:
-                stuck = True
-                for sample in xrange(1, len(ratios_equal_conc[index])):
-                    need = ratios_equal_conc[index][sample]*req_lanes.values()[index-1]
-                    cur = (acc_ratios[index][sample] - 1)*total_lanes[index-1]
-                    if sum(acc_ratios[index]) > 100 and cur >= need:
-                        acc_ratios[index][sample] -= 1
-                        stuck = False
-                    if sum(acc_ratios[index])== 100:
-                        break
-                if(stuck):
-                    total_lanes[index-1] += 1
-                    added = added + 1
-            
-    print "Lanes added due to pipette limitations: {}".format(added)                
-    return acc_ratios
+    #desired ratios = desired clusters per lane (for given sample) / clusters per lane
+    return [desired_ratios, needed_lanes, ideal_lanes]
 
-def generate_output(project, destid, total_lanes, req_lanes, lane_maps, acc_ratios, target_clusters, clusters_per_lane, extra_lanes,lane_volume,pool_excess):
+def integrate_conc_diff(lane_maps, desired_ratios):
+    """Since some samples are strong and some weaksauce
+    10% in desired_ratios does not mean 10% of lane volume
+    Ignores undetermined clusters in calculation
+    Sample conc assumably cant be altered; aka only volume is modified"""
+    
+    volume_ratios = dict()
+    conc_factor = dict()
+    
+    #FROM HERE NEEDS HEAVY REVISION
+    for key in desired_ratios:
+        #Assumes no samples had unequal volume in structure
+        #TODO: Use LIMS integration to avoid this assumption
+        actual_output = lane_maps[key]/sum(lane_maps[key])
+        
+        expect_output = []
+        expect_output.append(0.0) #Expect 0 undetermined
+        for index in xrange(1, len(lane_maps[key])):
+            expect_output.append(1/float(len(lane_maps[key]) -1))#-1 Removes undetermined
+        #TODO: One could include undetermined here
+        conc_factor[key] = actual_output/expect_output
+        #Division verified. One with high Actual/Expressed should naturally be less of in repool.
+        volume_ratios[key] = desired_ratios[key] / conc_factor[key]
+        #Merge down to 100%. Makes sense, since samples differ in volume.
+        if not sum(volume_ratios[key]) == 0:
+            volume_ratios[key] = volume_ratios[key]/sum(volume_ratios[key])
+        else: 
+            # Should fix NAN bug
+            volume_ratios[key] = 0
+        #TODO: Verify these numbers are correct, maybe volume_ratios/desired ratios or such?
+    return volume_ratios, conc_factor
+
+def realize_numbers(lane_maps, best_sample_struct, volume_ratios, conc_factor, clusters_rem, total_lanes, pool_excess, lane_volume, min_pipette):
+    """Actual numbers need to be offset to: 
+    Work with a pipette minimum and pipette threshold in relation to pool size (5 ul) + excess.
+    Lanesum is then downsized to sub 100% with as equal coverage as possible.
+    If impossible entire process is rerun with an extra lane for that struct.
+    """
+    extra_lanes=dict()
+    rounded_ratios = dict()
+    final_pool_sizes = dict() 
+    
+    #Remaining clusters for structure
+    rem_list = dict()
+    for key, values in best_sample_struct.items():
+        t_list = []
+        for name in best_sample_struct[key]:
+            t_list.append(clusters_rem[name])
+        rem_list[key] = numpy.array(t_list)
+    
+    #For each structure
+    for key, values in volume_ratios.items():
+        calculations_done = False
+        while not calculations_done:
+            poolsize = lane_volume*total_lanes[key] + pool_excess
+            minTres = round(min_pipette/poolsize, 6)
+            minAdd = round(0.1/poolsize, 6)
+            
+            #Rounds all values up
+            uprounded = []
+            for sample in values:
+                #Handles problems with Undetermined
+                if sample == 0:
+                    uprounded.append(0.0)
+                elif sample <= minTres:
+                    uprounded.append(minTres)
+                else:
+                    sample = sample-(sample%minAdd)
+                    uprounded.append(sample)
+            uprounded = numpy.array(uprounded)
+            
+            #Sets 'Undetermined's factor to 0, helps out later.
+            conc_factor[key][0] = 0
+            calculations_done = True
+            while sum(uprounded) > 1.0:
+                #Overexpression per sample (expressed - remaining). Expressed = ratio * clusters_per_lane * lanes
+                #Uprounded*conc_factor[key] SHOULD even out itself; since it only offsets ratios. Sum still 1
+                oe_list = (uprounded*conc_factor[key])*sum(lane_maps[key])*total_lanes[key] - rem_list[key]
+                #Order indexes in oe_list by value (descending)
+                max_index = oe_list.argsort()[::-1]
+                
+                stuck = True
+                for most_oe in max_index:
+                    #Remove one minAdd IF greater than minTres+minAdd AND (ratio-minAdd)*factor > remaining_clusters
+                    if uprounded[most_oe] >= minAdd + minTres and (uprounded[most_oe] - minAdd)*conc_factor[key][most_oe]*sum(lane_maps[key])*total_lanes[key] > rem_list[key][most_oe]:
+                        uprounded[most_oe] = uprounded[most_oe] - minAdd
+                        stuck = False
+                        break
+                #Add extra lane, restart the loop for the whole structure (new pool size)
+                if stuck:
+                    total_lanes[key] = total_lanes[key] + 1
+                    if not key in extra_lanes:
+                        extra_lanes[key] = 0
+                    extra_lanes[key] = extra_lanes[key] + 1
+                    calculations_done = False
+                    break
+                
+        final_pool_sizes[key] = poolsize*float(sum(uprounded))
+        ##TODO: Sum of output rounded_ratios is less than 100% before normalizing; Doublecheck results!     
+        rounded_ratios[key] = uprounded/float(sum(uprounded))
+    return [rounded_ratios, final_pool_sizes, extra_lanes]
+  
+
+def generate_output(project_id, dest_plate_list, best_sample_struct,total_lanes, req_lanes, lane_maps, rounded_ratios, 
+                    target_clusters, clusters_per_lane, extra_lanes, lane_volume, pool_excess, final_pool_sizes, volume_ratios, desired_ratios):
     """"Gathers the container id and well name for all samples in project"""
     timestamp = datetime.fromtimestamp(time()).strftime('%Y-%m-%d_%H:%M')
     
@@ -437,7 +401,7 @@ def generate_output(project, destid, total_lanes, req_lanes, lane_maps, acc_rati
     lims = Lims(BASEURI, USERNAME, PASSWORD)
     allProjects = lims.get_projects()
     for proj in allProjects:
-        if proj.id == project:
+        if proj.id == project_id:
             projName = proj.name 
             break
     
@@ -450,49 +414,66 @@ def generate_output(project, destid, total_lanes, req_lanes, lane_maps, acc_rati
         #For all artifacts in process
         for o in p.all_outputs():
             #If artifact is analyte type and has project name in sample
-            if o.type=="Analyte" and project in o.name:
+            if o.type=="Analyte" and project_id in o.name:
                 location[o.name.split()[0]] = list()
                 location[o.name.split()[0]].append(o.location[0].id)
                 location[o.name.split()[0]].append(o.location[1])
-   
-    generate_summary(projName, timestamp, project, destid, total_lanes, req_lanes, 
-                     lane_maps, acc_ratios, target_clusters, clusters_per_lane, extra_lanes)
-    generate_csv(projName, timestamp, location, destid, total_lanes, lane_maps, acc_ratios, lane_volume, pool_excess)
     
-def generate_summary(projName, timestamp, project, destid, total_lanes, req_lanes, lane_maps, acc_ratios, 
-                     target_clusters, clusters_per_lane, extra_lanes):                
+    #Continue coding from here
+    generate_summary(projName, best_sample_struct, timestamp, project_id, dest_plate_list, total_lanes, req_lanes, 
+                     lane_maps, rounded_ratios, target_clusters, clusters_per_lane, extra_lanes, volume_ratios, desired_ratios, lane_volume, pool_excess)
+    generate_csv(projName, timestamp, location, dest_plate_list, total_lanes, best_sample_struct, rounded_ratios, lane_volume, pool_excess, final_pool_sizes)
+    
+def generate_summary(projName, best_sample_struct, timestamp, project_id, dest_plate_list, total_lanes, req_lanes, lane_maps, rounded_ratios, 
+                     target_clusters, clusters_per_lane, extra_lanes, volume_ratios, desired_ratios, lane_volume, pool_excess):                
     """Print stats including duplicates"""
     
     sumName = '{}_summary_{}.txt'.format(projName, timestamp)
     with open(sumName, "w") as summary:
         if sum(req_lanes.values()) != 0:
-            OPT = sum(total_lanes)/sum(req_lanes.values())
+            OPT = sum(total_lanes.values())/sum(req_lanes.values())
         else: 
-            OPT = "ERROR"
+            raise Exception('Ideally zero more lanes are required. Unable to calcuate OPT!')  
         
         if OPT > 1.5:
             print("Warning, OPT exceeds 1.5x! Generated solution is so poor a better one can likely be done by hand!")
             
-        output = 'Target clusters per sample: {}, Expected clusters per lane: {}\n'.format(str(target_clusters), str(clusters_per_lane))    
-        output = output + 'Project ID: {}, Allow non-duplicate structures: {}\n'.format(project, str(allow_non_dupl_struct))
-        output = output + 'Destination plate name list: {}\n'.format(str(destid))
+        output = 'Target clusters per sample: {}, Expected clusters per lane: {}\n'.format(str(target_clusters), str(clusters_per_lane))  
+        output = output + 'Lane volume: {} microliter(s), Pool excess: {} microliter(s)\n'.format(lane_volume, pool_excess) 
+        output = output + 'Project ID: {}, Destination plate name list: {}\n'.format(project_id, str(dest_plate_list))
         output = (output + 'Ideal lanes (same schema): {}, Total lanes: {}, Expression over theoretical ideal (OPT): {}x\n'
-                  .format(str(round(sum(req_lanes.values()),3)), str(sum(total_lanes)), str(round(OPT,3))))
-        output = output + 'Lanes added to prevent sum of lane > 100%: {} (this can be mitigated with bigger pools).\n'.format(extra_lanes)
-        output = output + 'Unique pools: {}, Average pool duplication: {}\n'.format(str(len(total_lanes)), str(round(sum(total_lanes)/float(len(total_lanes)),3)))
+                  .format(str(round(sum(req_lanes.values()),3)), str(sum(total_lanes.values())), str(round(OPT,3))))
+        output = output + 'Lanes added due to pipette limitations: {} (this can be mitigated with bigger pools).\n'.format(sum(extra_lanes.values()))
+        output = output + 'Unique pools: {}, Average pool duplication: {}\n'.format(str(len(total_lanes.keys())), str(round(sum(total_lanes.values())/float(len(total_lanes.keys())),3)))
         summary.write( output )
         
         bin = 0
-        for index in xrange(1, len(lane_maps)+1):
-            bin  += 1
-            output = '\nLane {} to {}:\n'.format(str(bin), str(bin+int(total_lanes[index-1])-1))
-            summary.write( output )
-            bin += int(total_lanes[index-1]-1)
-            for counter in xrange(1, len(lane_maps[index])):
-                output = '{} {}%\n'.format(str(lane_maps[index][counter]), str(acc_ratios[index][counter]))
+        for key, value in best_sample_struct.items():
+            if total_lanes[key] > 0:
+                bin  += 1
+                if key in extra_lanes:
+                    output = '\nLane {:>2} to {:>2}+{}: {:>12} {:>12} {:>14} {:>7}\n'.format(str(bin), str(bin+int(total_lanes[key])-1),str(extra_lanes[key]),
+                                                                                      'Corrected Pipette', 'Minimum % (partial lanes)', 'Corrected Volume','Naive ratio')
+                    bin += int(total_lanes[key]-1+extra_lanes[key])
+                else:
+                    output = '\nLane {:>2} to {:>2}: {:>19} {:>12} {:>14} {:>7}\n'.format(str(bin), str(bin+int(total_lanes[key])-1),
+                                                                                          'Corrected Pipette','Minimum % (partial lanes)','Corrected Volume','Naive ratio')
+                    bin += int(total_lanes[key]-1)
                 summary.write( output )
                 
-def generate_csv(projName, timestamp, location, destid, total_lanes, lane_maps, acc_ratios, lane_volume, pool_excess):
+                for sample in xrange(1, len(value)):
+                    if sample != "Undetermined":
+                        #TODO: IS EACH PERCENTAGE BASED ON REQ OR TOTAL. ARE EXTRA LANES INCLUDED??
+                        if key in extra_lanes:
+                            lane_ratio = req_lanes[key]/(total_lanes[key]+extra_lanes[key])
+                        else:
+                            lane_ratio = req_lanes[key]/(total_lanes[key])
+                        output = '{:11}{:>22}%{:>25}%{:>16}%{:>11}%\n'.format(str(best_sample_struct[key][sample]), str(round(rounded_ratios[key][sample]*100,2)),
+                                                           str(round(volume_ratios[key][sample]*100*lane_ratio,2)), 
+                                                           str(round(volume_ratios[key][sample]*100,2)),str(round(desired_ratios[key][sample]*100,2)))
+                        summary.write( output )
+                
+def generate_csv(projName, timestamp, location, dest_plate_list, total_lanes, best_sample_struct, rounded_ratios, lane_volume, pool_excess, final_pool_sizes):
     """Creates the output csv file"""
     
     name = '{}_repool_{}.csv'.format(projName, timestamp)
@@ -503,37 +484,35 @@ def generate_csv(projName, timestamp, location, destid, total_lanes, lane_maps, 
     
     with open(name, 'w') as csvfile:
         writer = csv.writer(csvfile)
-        for index in xrange(1, len(lane_maps)+1):
+        for key, value in best_sample_struct.items():
             try:
-                destid[destNo]
+                dest_plate_list[destNo]
             except IndexError:
-                destid.append ('dp_{}'.format(str(destNo+1)))
+                dest_plate_list.append ('dp_{}'.format(str(destNo+1)))
                 #print "Critical error; not enough destination plates provided"
             
+            #TODO DOUBLECHECK THIS
             #Ugly constants
-            maxDupes = 200/5
-            dupes = int(total_lanes[index-1])
+            maxDupes = 200/final_pool_sizes[key]
+            dupes = int(total_lanes[key])
             
-            if lane_maps[index] == 0:
-                raise Exception('Error: Project not logged in x_flowcells database!')  
             if dupes > maxDupes:
                 raise Exception("Error: A pool has been requested that can't be fit into a single well!")
 
-            for counter in xrange(1, len(lane_maps[index])):
+            for instance in xrange(1, len(value)):
                 #<source plate ID>,<source well>,<volume>,<destination plate ID>,<destination well>
-                sample = lane_maps[index][counter]
+                sample = best_sample_struct[key][instance]
                 position = '{}:{}'.format(wells[wellIndex[1]], str(wellIndex[0]))
-                
                 try:
-                    #out_pool = acc_ratios[index][counter]/100*(float(lane_volume)*dupes+pool_excess)
-                    out_pool = acc_ratios[index][counter]/100*(float(lane_volume)*dupes)
-                    output = location[sample][0],location[sample][1],str(out_pool),str(destid[destNo]),position
+                    #TODO: THIS IS SOMEHOW WRONG.. FIGURE OUT WHY
+                    out_pool = round(rounded_ratios[key][instance]*final_pool_sizes[key],2)
+                    output = location[sample][0],location[sample][1],str(out_pool),str(dest_plate_list[destNo]),position
                 except KeyError:
                     print "Error: Samples incorrectly parsed into database, thus causing sample name conflicts!"
-                if not acc_ratios[index][counter] == 0:
+                if not rounded_ratios[key][instance] == 0:
                     writer.writerow(output)
             #Increment wellsindex
-            if not acc_ratios[index][counter] == 0:
+            if not rounded_ratios[key][instance] == 0:
                 if not wellIndex[1] >= 8:
                     wellIndex[1] += 1
                 else:
@@ -545,7 +524,7 @@ def generate_csv(projName, timestamp, location, destid, total_lanes, lane_maps, 
                         destNo += 1
                       
 @click.command()
-@click.option('--project_id', required=True,help='ID of project to repool. Examples:P2652, P1312 etc.')
+@click.option('--project_id', required=True,help='ID of project to repool. \nExamples: P2652, P1312 etc.')
 @click.option('--dest_plate_list', default=['dp_1'], 
               help='List of destination plates for the robot\'s csv file. Include too many rather than too few; excess will be unused. Default: [dp_1]') 
 @click.option('--target_clusters', default=320*1000000, help='Threshold of clusters per sample. \nDefault:320*1000000')
@@ -557,15 +536,21 @@ def generate_csv(projName, timestamp, location, destid, total_lanes, lane_maps, 
 def main(target_clusters, clusters_per_lane, project_id, dest_plate_list, lane_volume, pool_excess, min_pipette):
     """Application that calculates samples under threshold for a project, then calculate the optimal composition for reaching the threshold
     without altering concentrations nor the structure of the pools. Outputs both a summary as well as a functional csv file."""  
+    print("WARNING: Output from repooler is experimental. Remember to review all numbers before re-sequencing.")
+    print("WARNING: Repooler relies on the assumption that all sample had equal volume within a lane.")
+    print("Q: Massive integrate_conc_diff TODO. Check it out !!")
+    
     couch = connection()
     structure = proj_struct(couch, project_id, target_clusters)
-    [all_lane_maps, clusters_rem, sample_struct] = parse_indata(structure, target_clusters)
-    lane_maps = simple_unique_set(sample_struct, clusters_rem, target_clusters)
-    [ratios_equal_conc, req_lanes, total_lanes] = sample_distributor(lane_maps, clusters_rem, clusters_per_lane)
-    acc_ratios, extra_lanes = realize_numbers(lane_maps, lane_maps, ratios_equal_conc, req_lanes, total_lanes)
-    generate_output(project_id, dest_plate_list, total_lanes, req_lanes, lane_maps, acc_ratios, 
-                    target_clusters, clusters_per_lane, extra_lanes,lane_volume,pool_excess)    
-
-    print("WARN: Output from repooler is experimental. Remember to review all numbers before re-sequencing.")
+    [lane_maps, clusters_rem, sample_struct] = parse_indata(structure, target_clusters)
+    best_sample_struct = simple_unique_set(sample_struct, clusters_rem, target_clusters)
+    [desired_ratios, total_lanes, req_lanes] = sample_distributor(best_sample_struct, clusters_rem, clusters_per_lane)
+    #Verify from here
+    [volume_ratios, conc_factor] = integrate_conc_diff(lane_maps, desired_ratios)
+    [rounded_ratios, final_pool_sizes, extra_lanes] = realize_numbers(lane_maps, best_sample_struct, volume_ratios, conc_factor, 
+                                                                      clusters_rem, total_lanes, pool_excess, lane_volume, min_pipette)
+    
+    generate_output(project_id, dest_plate_list, best_sample_struct, total_lanes, req_lanes, lane_maps, rounded_ratios, 
+                    target_clusters, clusters_per_lane, extra_lanes,lane_volume,pool_excess, final_pool_sizes, volume_ratios, desired_ratios)    
 if __name__ == '__main__':
     main()

--- a/repooler.py
+++ b/repooler.py
@@ -245,17 +245,6 @@ def validate_all_samples_present(subset_struct, sample_struct, clusters_rem):
                 break
         if not found:
             raise Exception('Error: Sample missing after subset was generated! {} is one of these'.format(element))
-    
-def aggregator(lane_maps,clusters_rem,clusters_per_lane):
-#Iterate
-    #Find all samples that are also expressed in another struct
-    #Sort those structs by duplication
-    #Fill them to floor(dups); unless mod % 1 > some_number; then ceil(dups)
-    #Note the remaining necessary
-#End
-    #Use the remaining structs
-    #Ceil(dups) those babies
-    raise Exception('Error: Not yet implemented!')
 
 def sample_distributor(sample_struct, clusters_rem, clusters_per_lane): 
     """Gives the percentage volume each sample should have in a lane, BEFORE accounting
@@ -317,7 +306,6 @@ def integrate_conc_diff(lane_maps, desired_ratios):
         else: 
             # Should fix NAN bug
             volume_ratios[key] = 0
-        #TODO: Verify these numbers are correct, maybe volume_ratios/desired ratios or such?
     return volume_ratios, conc_factor
 
 def realize_numbers(lane_maps, best_sample_struct, volume_ratios, conc_factor, clusters_rem, total_lanes, pool_excess, lane_volume, min_pipette):
@@ -386,7 +374,7 @@ def realize_numbers(lane_maps, best_sample_struct, volume_ratios, conc_factor, c
                     break
                 
         final_pool_sizes[key] = poolsize*float(sum(uprounded))
-        ##TODO: Sum of output rounded_ratios is less than 100% before normalizing; Doublecheck results!     
+        ##TODO: Sum of output rounded_ratios is less than 100% before normalizing; weird but likely correct. 
         rounded_ratios[key] = uprounded/float(sum(uprounded))
     return [rounded_ratios, final_pool_sizes, extra_lanes]
   
@@ -463,7 +451,6 @@ def generate_summary(projName, best_sample_struct, timestamp, project_id, dest_p
                 
                 for sample in xrange(1, len(value)):
                     if sample != "Undetermined":
-                        #TODO: IS EACH PERCENTAGE BASED ON REQ OR TOTAL. ARE EXTRA LANES INCLUDED??
                         if key in extra_lanes:
                             lane_ratio = req_lanes[key]/(total_lanes[key]+extra_lanes[key])
                         else:
@@ -504,7 +491,6 @@ def generate_csv(projName, timestamp, location, dest_plate_list, total_lanes, be
                 sample = best_sample_struct[key][instance]
                 position = '{}:{}'.format(wells[wellIndex[1]], str(wellIndex[0]))
                 try:
-                    #TODO: THIS IS SOMEHOW WRONG.. FIGURE OUT WHY
                     out_pool = round(rounded_ratios[key][instance]*final_pool_sizes[key],2)
                     output = location[sample][0],location[sample][1],str(out_pool),str(dest_plate_list[destNo]),position
                 except KeyError:
@@ -545,7 +531,6 @@ def main(target_clusters, clusters_per_lane, project_id, dest_plate_list, lane_v
     [lane_maps, clusters_rem, sample_struct] = parse_indata(structure, target_clusters)
     best_sample_struct = simple_unique_set(sample_struct, clusters_rem, target_clusters)
     [desired_ratios, total_lanes, req_lanes] = sample_distributor(best_sample_struct, clusters_rem, clusters_per_lane)
-    #Verify from here
     [volume_ratios, conc_factor] = integrate_conc_diff(lane_maps, desired_ratios)
     [rounded_ratios, final_pool_sizes, extra_lanes] = realize_numbers(lane_maps, best_sample_struct, volume_ratios, conc_factor, 
                                                                       clusters_rem, total_lanes, pool_excess, lane_volume, min_pipette)


### PR DESCRIPTION
- Cleaned up the code
- Massively increased the info in the summary
- Rewrote the code to produce pools in the csv file rather than lanes
- Wrote support for dynamic volume per lane and pool excess volume
- Sample structure is now dictacted by "most samples that still needs to be sequenced"
- Coverage of each sample should now be more even
- Concentration strength is now calculated per sample of each structure rather than per sample for the whole project
- Statusdb credentials are now set outside the script
- All data structures have been rewritten to not use magical numbers and just generally behave better