### PR TITLE
Pricing statusdb - Draft releases and last updated field per item

### DIFF
--- a/push_new_pricing_to_statusdb.py
+++ b/push_new_pricing_to_statusdb.py
@@ -193,7 +193,7 @@ def load_products(wb):
                                     row
                                 )
                     new_product['fixed_price']['price_in_sek'] = ws[int_cell].value
-                    new_product['fixed_price']['price_per_unit_in_sek'] = ws[ext_cell].value
+                    new_product['fixed_price']['external_price_in_sek'] = ws[ext_cell].value
 
             new_product[header_val] = val
 

--- a/push_new_pricing_to_statusdb.py
+++ b/push_new_pricing_to_statusdb.py
@@ -143,7 +143,10 @@ def load_products(wb):
                 val = val.replace('.', ',')
                 if val:
                     # Make a list with all individual components
-                    val = [int(prod_id) for prod_id in val.split(',')]
+                    val_list = [int(prod_id) for prod_id in val.split(',')]
+
+                    val = {comp_ref_id: {'quantity': 1} for comp_ref_id in val_list}
+
             new_product[header_val] = val
 
         if not is_empty_row(new_product):

--- a/push_new_pricing_to_statusdb.py
+++ b/push_new_pricing_to_statusdb.py
@@ -142,10 +142,9 @@ def load_products(wb):
     product_price_columns = {}
     for cell in header_cells:
         cell_val = cell.value
-
+        # Get cell column as string
+        cell_column = cell.coordinate.replace(str(header_row), '')
         if cell_val not in SKIP['products']:
-            # Get cell column as string
-            cell_column = cell.coordinate.replace(str(header_row), '')
             header[cell_column] = cell_val
         else:
             # save a lookup to find column of prices
@@ -193,8 +192,8 @@ def load_products(wb):
                                     product_price_columns['External'],
                                     row
                                 )
-                    new_product['fixed_price']['price_in_sek'] = ws[int_cell]
-                    new_product['fixed_price']['price_per_unit_in_sek'] = ws[ext_cell]
+                    new_product['fixed_price']['price_in_sek'] = ws[int_cell].value
+                    new_product['fixed_price']['price_per_unit_in_sek'] = ws[ext_cell].value
 
             new_product[header_val] = val
 


### PR DESCRIPTION
This introduces a 'Draft' field on each document. The intention is that there should maximum be one Draft document at each time point and in that case that one should be the latest. The draft document will be the one edited (in the future) when updating prices.

This script is now divided so that it either pushes a draft to the database OR publishes the draft in the database. The publish action is just setting `'Draft'=false`.

Again, this script is temporary until its functionality is implemented directly through Genomics Status.

Furthermore, each item (component or product) has a 'Last Updated' field which will be useful when checking which items needs to be reviewed. 

I also changed the logic so that one have to upload both products and components at the same time. This will ensure that the versions of these are kept in sync.

Finally, I changed to keep id:s as strings (but they should be valid integers) since I had some issues with statusdb storing the integers as strings anyway.