### PR TITLE
Clean-up Back-up

### DIFF
--- a/del_bupp_files.py
+++ b/del_bupp_files.py
@@ -22,8 +22,7 @@ def main(args):
             file_date = datetime.datetime.strptime(bn[0:10], "%Y-%m-%d")
 
         if file_date is None:
-            sys.stderr.write("Error {} was not possible to parse.".format(f))
-            sys.exit(-1)
+            continue
 
         # Save backups from April, August, December
         # Remove others older than 90 days

--- a/del_bupp_files.py
+++ b/del_bupp_files.py
@@ -22,7 +22,7 @@ def main(args):
             file_date = datetime.datetime.strptime(bn[0:10], "%Y-%m-%d")
 
         if file_date is None:
-            sys.stderr.write("Error {} was not possible to parse.".format(file_date))
+            sys.stderr.write("Error {} was not possible to parse.".format(f))
             sys.exit(-1)
 
         # Save backups from April, August, December

--- a/del_bupp_files.py
+++ b/del_bupp_files.py
@@ -14,10 +14,10 @@ def main(args):
     files = glob.glob("/home/bupp/other/*")
     for f in files:
         bn = os.path.basename(f)
-        if args.mode == 'github':
+        if args.mode == 'github' and 'github' in f:
             file_date = datetime.datetime.strptime(bn[13:23], "%Y-%m-%d")
             
-        if args.mode == 'zendesk':
+        if args.mode == 'zendesk' and 'github' not in f:
             file_date = datetime.datetime.strptime(bn[0:10], "%Y-%m-%d")
 
         # Save backups from April, August, December

--- a/del_bupp_files.py
+++ b/del_bupp_files.py
@@ -30,14 +30,14 @@ def main(args):
             if args.danger:
                 os.remove(f)
             else:
-                sys.stderr.write("Would have removed {}".format(f))
+                sys.stderr.write("Would have removed {}\n".format(f))
 
         # Remove everything older than approx 2 years
         if (datetime.datetime.now() - file_date).days > 600:
             if args.danger:
                 os.remove(f)
             else:
-                sys.stderr.write("Would have removed {}".format(f))
+                sys.stderr.write("Would have removed {}\n".format(f))
 
 
 if __name__ == "__main__":

--- a/del_bupp_files.py
+++ b/del_bupp_files.py
@@ -16,9 +16,11 @@ def main(args):
         bn = os.path.basename(f)
         file_date = None
         if args.mode == 'github' and 'github' in f:
+            # Typical file name: githubbackup_2019-09-09T15:42:39.980130.tar.gz
             file_date = datetime.datetime.strptime(bn[13:23], "%Y-%m-%d")
-            
+
         if args.mode == 'zendesk' and 'github' not in f:
+            # Typical file name: 2019-09-09_16-33.bckp.json
             file_date = datetime.datetime.strptime(bn[0:10], "%Y-%m-%d")
 
         if file_date is None:

--- a/del_bupp_files.py
+++ b/del_bupp_files.py
@@ -14,11 +14,16 @@ def main(args):
     files = glob.glob("/home/bupp/other/*")
     for f in files:
         bn = os.path.basename(f)
+        file_date = None
         if args.mode == 'github' and 'github' in f:
             file_date = datetime.datetime.strptime(bn[13:23], "%Y-%m-%d")
             
         if args.mode == 'zendesk' and 'github' not in f:
             file_date = datetime.datetime.strptime(bn[0:10], "%Y-%m-%d")
+
+        if file_date is None:
+            sys.stderr.write("Error {} was not possible to parse.".format(file_date)
+            sys.exit(-1)
 
         # Save backups from April, August, December
         # Remove others older than 90 days
@@ -34,8 +39,6 @@ def main(args):
                 os.remove(f)
             else:
                 sys.stderr.write("Would have removed {}".format(f))
-
-
 
 
 if __name__ == "__main__":

--- a/del_bupp_files.py
+++ b/del_bupp_files.py
@@ -22,7 +22,7 @@ def main(args):
             file_date = datetime.datetime.strptime(bn[0:10], "%Y-%m-%d")
 
         if file_date is None:
-            sys.stderr.write("Error {} was not possible to parse.".format(file_date)
+            sys.stderr.write("Error {} was not possible to parse.".format(file_date))
             sys.exit(-1)
 
         # Save backups from April, August, December

--- a/del_bupp_files.py
+++ b/del_bupp_files.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+"""A script to clean up among files which will be backed up on tape.
+
+slightly adapted from the original, kindly supplied by it-support@scilifelab.se.
+"""
+
+import glob
+import datetime
+import os
+import argparse
+import sys
+
+def main(args):
+    files = glob.glob("/home/bupp/other/*")
+    for f in files:
+        bn = os.path.basename(f)
+        if args.mode == 'github':
+            file_date = datetime.datetime.strptime(bn[13:23], "%Y-%m-%d")
+            
+        if args.mode == 'zendesk':
+            file_date = datetime.datetime.strptime(bn[0:10], "%Y-%m-%d")
+
+        # Save backups from April, August, December
+        # Remove others older than 90 days
+        if ((datetime.datetime.now() - file_date).days > 90 and file_date.month % 4):
+            if args.danger:
+                os.remove(f)
+            else:
+                sys.stderr.write("Would have removed {}".format(f))
+
+        # Remove everything older than approx 2 years
+        if (datetime.datetime.now() - file_date).days > 600:
+            if args.danger:
+                os.remove(f)
+            else:
+                sys.stderr.write("Would have removed {}".format(f))
+
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=['github', 'zendesk'])
+    parser.add_argument("--danger", action="store_true", help="Without this, no files will be deleted")
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
A script to cleanup the directory which is backed up to tape. In this we store github and zendesk backups.

This script will be run every day or every week and will:
 - Keep backups from every fourth month
 - The most recent ones are all kept for 90 days
 - Everything older than 600 days are erased

These rules are all very random, so please if you think they are strange, feel free to suggest changes. 