### PR TITLE
GitHub backup api fix

### DIFF
--- a/backup_github.py
+++ b/backup_github.py
@@ -73,6 +73,7 @@ def backup(user, password, access_token, organizations, dest):
                 os.mkdir(organization_destination_path)
 
     for repository in chain(*repositories):
+        logger.info("Github API rate limit: {}".format(github_instance.get_rate_limit()))
         if password is not None and repository.private is True:
             source = repository.clone_url.replace(
                                 "https://",


### PR DESCRIPTION
 - Added access token to improve rate limit from 60 per hour to 5000 per hour
 - Dropped command line username and password in favour of the credentials file

Tested on ngi-internal-dev, but will test run manually on ngi-internal when merged.