### PR TITLE
Fixing strange error where euro exchange rates was a string for new API

### DIFF
--- a/update_exchange_rates.py
+++ b/update_exchange_rates.py
@@ -33,6 +33,10 @@ def main(config, push_to_server=False):
     usd_to_sek = c.get_rate('USD', 'SEK')
     eur_to_sek = c.get_rate('EUR', 'SEK')
 
+    # Inconsistent results for Euro after broken API was updated
+    if isinstance(eur_to_sek, str):
+        eur_to_sek = float(eur_to_sek)
+
     # Create the doc that will be uploaded
     doc = {}
     doc['Issued at'] = datetime.datetime.now().isoformat()


### PR DESCRIPTION
Needed to upgrade the `forex-python` package since the old API URL has gone missing. However the new version retuerned a string for the euro conversion rate instead of a float which is fixed here.