### PR TITLE
Use tacas statusdb module instead of old statusdb module

### DIFF
--- a/get_sample_names.py
+++ b/get_sample_names.py
@@ -10,8 +10,7 @@ if len(sys.argv) == 1:
 prj = sys.argv[1]
 
 statusdb_config = os.getenv('STATUS_DB_CONFIG')
-conf = load_config(statusdb_config)
-conf = conf.get('statusdb')
+conf = load_config(statusdb_config).get('statusdb')
 
 pcon = ProjectSummaryConnection(config=conf)
 prj_obj = pcon.get_entry(prj)

--- a/get_sample_names.py
+++ b/get_sample_names.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
 
 import sys
-from statusdb.db import connections as statusdb
+import os
+from taca.utils.statusdb import ProjectSummaryConnection
+from taca.utils.config import load_config
 
 if len(sys.argv) == 1:
     sys.exit('Please provide a project name')
 prj = sys.argv[1]
 
-pcon = statusdb.ProjectSummaryConnection()
+statusdb_config = os.getenv('STATUS_DB_CONFIG')
+conf = load_config(statusdb_config)
+conf = conf.get('statusdb')
+
+pcon = ProjectSummaryConnection(config=conf)
 prj_obj = pcon.get_entry(prj)
 prj_samples = prj_obj.get('samples',{})
 


### PR DESCRIPTION
Requires `STATUS_DB_CONFIG` to be set but it should be if running on the NGI env on Miarka